### PR TITLE
Bug/return 404 on delete

### DIFF
--- a/__tests__/routes/serviceTypes.test.js
+++ b/__tests__/routes/serviceTypes.test.js
@@ -22,6 +22,9 @@ describe('service types router endpoints', () => {
   beforeAll(() => {
     // This is the module/route being tested
     server.use(['/service_type', '/service_types'], serviceTypeRouter);
+  });
+
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
@@ -84,6 +87,26 @@ describe('service types router endpoints', () => {
       expect(res.status).toBe(200);
       expect(res.body.service_type.name).toBe('Rental Assistance');
       expect(ServiceTypes.update.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('DELETE /service_type/:id', () => {
+    it('should return 200 when service_type is deleted', async () => {
+      DB.remove.mockResolvedValue(1);
+      const res = await request(server).delete('/service_type/5');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Service Type 5 has been removed');
+      expect(DB.remove.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when service_type id is invalid', async () => {
+      DB.remove.mockResolvedValue(0);
+      const res = await request(server).delete('/service_type/5');
+
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Service Type 5 could not be found');
+      expect(DB.remove.mock.calls.length).toBe(1);
     });
   });
 });

--- a/__tests__/routes/statuses.test.js
+++ b/__tests__/routes/statuses.test.js
@@ -20,6 +20,9 @@ describe('status router endpoints', () => {
   beforeAll(() => {
     // This is the module/route being tested
     server.use(['/status', '/statuses'], statusRouter);
+  });
+
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
@@ -79,6 +82,26 @@ describe('status router endpoints', () => {
       expect(res.body.message).toBe('Status 5 updated');
       expect(res.body.status.name).toBe('Needs Attention');
       expect(DB.update.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('DELETE /status/:id', () => {
+    it('should return 200 when status is deleted', async () => {
+      DB.remove.mockResolvedValue(1);
+      const res = await request(server).delete('/status/5');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Status 5 has been removed');
+      expect(DB.remove.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when status id is invalid', async () => {
+      DB.remove.mockResolvedValue(0);
+      const res = await request(server).delete('/status/5');
+
+      expect(res.status).toBe(404);
+      expect(res.body.message).toBe('Status 5 could not be found');
+      expect(DB.remove.mock.calls.length).toBe(1);
     });
   });
 });

--- a/api/program/programRouter.js
+++ b/api/program/programRouter.js
@@ -78,8 +78,12 @@ router.delete('/:id', canCrudServiceType, (req, res) => {
   const { id } = req.params;
 
   DB.remove('programs', id)
-    .then(() => {
-      res.status(200).json({ message: `Program ${id} has been removed` });
+    .then((count) => {
+      if (count > 0) {
+        res.status(200).json({ message: `Program ${id} has been removed` });
+      } else {
+        res.status(404).json({ message: `Program ${id} could not be found` });
+      }
     })
     .catch((err) => {
       res.status(500).json({ error: err.message });

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -52,8 +52,16 @@ router.delete('/:id', (req, res) => {
   const { id } = req.params;
 
   DB.remove('service_entries', id)
-    .then(() => {
-      res.status(200).json({ message: `Entry ${id} has been removed` });
+    .then((count) => {
+      if (count > 0) {
+        res
+          .status(200)
+          .json({ message: `Service Entry ${id} has been removed` });
+      } else {
+        res
+          .status(404)
+          .json({ message: `Service Entry ${id} could not be found` });
+      }
     })
     .catch((err) => {
       res.status(500).json({ error: err.message });

--- a/api/statuses/statusesRouter.js
+++ b/api/statuses/statusesRouter.js
@@ -56,8 +56,12 @@ router.delete('/:id', requireAdmin, (req, res) => {
   const { id } = req.params;
 
   DB.remove('statuses', id)
-    .then(() => {
-      res.status(200).json({ message: `Status ${id} has been removed` });
+    .then((count) => {
+      if (count > 0) {
+        res.status(200).json({ message: `Status ${id} has been removed` });
+      } else {
+        res.status(404).json({ message: `Status ${id} could not be found` });
+      }
     })
     .catch((err) => {
       res.status(500).json({ error: err.message });


### PR DESCRIPTION
Most of our routes were returning 200 OKs for delete requests on IDs that weren't in the database. This PR fixes that to return 404s when the ID doesn't exist. It also adds tests for delete on routes that we already have initial test suites set up. 