### PR TITLE
Feature/get all service providers

### DIFF
--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -27,6 +27,12 @@ const findById = async (id) => {
     .first();
 };
 
+const findServiceProviders = () => {
+  return knex('profiles')
+    .select('firstName', 'lastName')
+    .where('role', 'service_provider');
+};
+
 const update = async (id, updates) => {
   const { programs, ...profile } = updates;
 
@@ -87,4 +93,5 @@ module.exports = {
   findAll,
   findById,
   update,
+  findServiceProviders,
 };

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -172,6 +172,16 @@ router.get('/', function (req, res) {
  *      404:
  *        description: 'Profile not found'
  */
+
+router.get('/getServiceProviders', function (req, res) {
+  Profiles.findServiceProviders()
+    .then((serviceProviders) => {
+      res.status(200).json(serviceProviders);
+    })
+    .catch((err) => {
+      res.status(404).json({ error: 'No Service Providers Found' });
+    });
+});
 router.get('/:id', function (req, res) {
   const id = String(req.params.id);
   Profiles.findById(id)

--- a/api/profile/profileRouter.js
+++ b/api/profile/profileRouter.js
@@ -178,10 +178,11 @@ router.get('/getServiceProviders', function (req, res) {
     .then((serviceProviders) => {
       res.status(200).json(serviceProviders);
     })
-    .catch((err) => {
+    .catch(() => {
       res.status(404).json({ error: 'No Service Providers Found' });
     });
 });
+
 router.get('/:id', function (req, res) {
   const id = String(req.params.id);
   Profiles.findById(id)


### PR DESCRIPTION
- Added endpoint in ProfileRouter to specifically grab service_providers from profiles table for use in the service entries form.
- Work included adding model function, and including a separate router path.
- User story "I can view services as a display on applicable pages"
- Endpoint tested locally
- Peer reviewed with Andrew Sohrabi via Zoom