### PR TITLE
Adds unsigned to value and quantity columns in service_entries table

### DIFF
--- a/data/migrations/007-service_entries.js
+++ b/data/migrations/007-service_entries.js
@@ -10,8 +10,8 @@ exports.up = function (knex) {
     tbl.datetime('provided_at').notNullable();
     tbl.text('notes');
     tbl.string('unit').notNullable();
-    tbl.integer('quantity').notNullable();
-    tbl.decimal('value').notNullable();
+    tbl.integer('quantity').notNullable().unsigned();
+    tbl.decimal('value').notNullable().unsigned();
     tbl
       .integer('recipient_id')
       .unsigned()


### PR DESCRIPTION
- Added "unsigned" to quantity and value columns in the service_entries table to prevent negative values from being passed in.
- Reviewed by team
- Fix has been locally tested
