### PR TITLE
adds id to findServiceProviders model

### DIFF
--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -29,7 +29,7 @@ const findById = async (id) => {
 
 const findServiceProviders = () => {
   return knex('profiles')
-    .select('firstName', 'lastName')
+    .select('id', 'firstName', 'lastName')
     .where('role', 'service_provider');
 };
 


### PR DESCRIPTION
This PR just updates a model to return an id for service providers along with their name. This will allow the frontend to have the id to pass back along as the provider_id when creating new service_entries. 