### PR TITLE
Feature/add service entries model

### DIFF
--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -49,33 +49,6 @@ const findById = async (id) => {
     );
 };
 
-// need to return the single newly created service_entry **only
-const create = async (object) => {
-  return await knex('service_entries')
-    .insert(object)
-    .leftJoin('recipients', {
-      'service_entries.recipient_id': 'recipients.id',
-    })
-    .rightJoin('service_types', {
-      'service_entries.service_type_id': 'service_types.id',
-    })
-    .rightJoin('statuses', {
-      'service_entries.status_id': 'statuses.id',
-    })
-    .select(
-      knex.raw(
-        'service_entries.*, recipients.first_name, recipients.last_name, service_types.name as service_type_name, statuses.name as status_name'
-      )
-    )
-    .groupBy(
-      'service_entries.id',
-      'recipients.id',
-      'service_types.id',
-      'statuses.id'
-    )
-    .returning('*');
-};
-
 // Can only update service_entries data in table on front end
 // Can't update "extra" data that's tacked onto the responses
 // Can't edit: first_name, last_name, service_type_name, status_name
@@ -90,6 +63,5 @@ const update = (id, object) => {
 module.exports = {
   findAll,
   findById,
-  create,
   update,
 };

--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -26,6 +26,7 @@ const findAll = async () => {
 
 const findById = async (id) => {
   return await knex('service_entries')
+    .where({ 'service_entries.id': id })
     .leftJoin('recipients', {
       'service_entries.recipient_id': 'recipients.id',
     })
@@ -37,19 +38,18 @@ const findById = async (id) => {
     })
     .select(
       knex.raw(
-        'service_entries.*, to_json(recipients.*) as recipient, to_json(service_types.*) as service_type, to_json(statuses.*) as status'
+        'service_entries.*, recipients.first_name, recipients.last_name, service_types.name as service_type_name, statuses.name as status_name'
       )
     )
-    .where({ 'service_entries.id': id })
     .groupBy(
       'service_entries.id',
       'recipients.id',
       'service_types.id',
       'statuses.id'
-    )
-    .first();
+    );
 };
 
+// need to return the single newly created service_entry **only
 const create = async () => {
   return await knex('service_entries')
     .leftJoin('recipients', {
@@ -72,28 +72,6 @@ const create = async () => {
       'service_types.id',
       'statuses.id'
     );
-  // return await knex('service_entries')
-  //   .leftJoin('recipients', {
-  //     'service_entries.recipient_id': 'recipients.id',
-  //   })
-  //   .rightJoin('service_types', {
-  //     'service_entries.service_type_id': 'service_types.id',
-  //   })
-  //   .rightJoin('statuses', {
-  //     'service_entries.status_id': 'statuses.id',
-  //   })
-  //   .select(
-  //     knex.raw(
-  //       'service_entries.*, to_json(recipients.*) as recipient, to_json(service_types.*) as service_type, to_json(statuses.*) as status'
-  //     )
-  //   )
-  //   .groupBy(
-  //     'service_entries.id',
-  //     'recipients.id',
-  //     'service_types.id',
-  //     'statuses.id'
-  //   )
-  //   .where({ 'service_entries.id': id });
 };
 
 module.exports = {

--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -50,8 +50,9 @@ const findById = async (id) => {
 };
 
 // need to return the single newly created service_entry **only
-const create = async () => {
+const create = async (object) => {
   return await knex('service_entries')
+    .insert(object)
     .leftJoin('recipients', {
       'service_entries.recipient_id': 'recipients.id',
     })
@@ -71,11 +72,24 @@ const create = async () => {
       'recipients.id',
       'service_types.id',
       'statuses.id'
-    );
+    )
+    .returning('*');
+};
+
+// Can only update service_entries data in table on front end
+// Can't update "extra" data that's tacked onto the responses
+// Can't edit: first_name, last_name, service_type_name, status_name
+const update = (id, object) => {
+  return knex('service_entries')
+    .where({ id: id })
+    .first()
+    .update(object)
+    .returning('*');
 };
 
 module.exports = {
   findAll,
   findById,
   create,
+  update,
 };

--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -24,6 +24,80 @@ const findAll = async () => {
     );
 };
 
+const findById = async (id) => {
+  return await knex('service_entries')
+    .leftJoin('recipients', {
+      'service_entries.recipient_id': 'recipients.id',
+    })
+    .rightJoin('service_types', {
+      'service_entries.service_type_id': 'service_types.id',
+    })
+    .rightJoin('statuses', {
+      'service_entries.status_id': 'statuses.id',
+    })
+    .select(
+      knex.raw(
+        'service_entries.*, to_json(recipients.*) as recipient, to_json(service_types.*) as service_type, to_json(statuses.*) as status'
+      )
+    )
+    .where({ 'service_entries.id': id })
+    .groupBy(
+      'service_entries.id',
+      'recipients.id',
+      'service_types.id',
+      'statuses.id'
+    )
+    .first();
+};
+
+const create = async () => {
+  return await knex('service_entries')
+    .leftJoin('recipients', {
+      'service_entries.recipient_id': 'recipients.id',
+    })
+    .rightJoin('service_types', {
+      'service_entries.service_type_id': 'service_types.id',
+    })
+    .rightJoin('statuses', {
+      'service_entries.status_id': 'statuses.id',
+    })
+    .select(
+      knex.raw(
+        'service_entries.*, recipients.first_name, recipients.last_name, service_types.name as service_type_name, statuses.name as status_name'
+      )
+    )
+    .groupBy(
+      'service_entries.id',
+      'recipients.id',
+      'service_types.id',
+      'statuses.id'
+    );
+  // return await knex('service_entries')
+  //   .leftJoin('recipients', {
+  //     'service_entries.recipient_id': 'recipients.id',
+  //   })
+  //   .rightJoin('service_types', {
+  //     'service_entries.service_type_id': 'service_types.id',
+  //   })
+  //   .rightJoin('statuses', {
+  //     'service_entries.status_id': 'statuses.id',
+  //   })
+  //   .select(
+  //     knex.raw(
+  //       'service_entries.*, to_json(recipients.*) as recipient, to_json(service_types.*) as service_type, to_json(statuses.*) as status'
+  //     )
+  //   )
+  //   .groupBy(
+  //     'service_entries.id',
+  //     'recipients.id',
+  //     'service_types.id',
+  //     'statuses.id'
+  //   )
+  //   .where({ 'service_entries.id': id });
+};
+
 module.exports = {
   findAll,
+  findById,
+  create,
 };

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -16,7 +16,7 @@ router.get('/', (req, res) => {
 router.get('/:id', (req, res) => {
   const { id } = req.params;
 
-  DB.findById('service_entries', id)
+  ServiceEntries.findById(id)
     .then((entry) => {
       if (entry) {
         res.status(200).json(entry);

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -31,7 +31,6 @@ router.get('/:id', (req, res) => {
 router.post('/', (req, res) => {
   DB.create('service_entries', req.body)
     .then((response) => {
-      console.log(response);
       return ServiceEntries.findById(response[0].id);
     })
     .then((newEntry) => {

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -30,7 +30,7 @@ router.get('/:id', (req, res) => {
 });
 
 router.post('/', (req, res) => {
-  DB.create('service_entries', req.body)
+  ServiceEntries.create('service_entries', req.body)
     .then((newEntry) => {
       res.status(201).json(newEntry);
     })

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -15,7 +15,6 @@ router.get('/', (req, res) => {
 
 router.get('/:id', (req, res) => {
   const { id } = req.params;
-
   ServiceEntries.findById(id)
     .then((entry) => {
       if (entry) {
@@ -30,7 +29,11 @@ router.get('/:id', (req, res) => {
 });
 
 router.post('/', (req, res) => {
-  ServiceEntries.create('service_entries', req.body)
+  DB.create('service_entries', req.body)
+    .then((response) => {
+      console.log(response);
+      return ServiceEntries.findById(response[0].id);
+    })
     .then((newEntry) => {
       res.status(201).json(newEntry);
     })
@@ -40,7 +43,7 @@ router.post('/', (req, res) => {
 });
 
 router.put('/:id', (req, res) => {
-  DB.update('service_entries', req.params.id, req.body)
+  ServiceEntries.update(req.params.id, req.body)
     .then((editedEntry) => {
       res.status(200).json(editedEntry);
     })
@@ -51,7 +54,6 @@ router.put('/:id', (req, res) => {
 
 router.delete('/:id', (req, res) => {
   const { id } = req.params;
-
   DB.remove('service_entries', id)
     .then((count) => {
       if (count > 0) {


### PR DESCRIPTION
- Invited Tara and Jennifer for review

- Modified POST route in serviceEntriesRouter.js and created new findById model in serviceEntriesModel.js.
- Instead of creating an entirely new "create" method to produce the necessary response data. We decided to use promise chaining to combine an existing model with our newly created findById to achieve our desired response.

- We made these modifications to improve performance by reducing the amount of API calls the front end service table was making to get the additional data they needed

_Previous response object when making POST request:_
```
{
  "id": 
  "service_type_id":
  "provided_at": 
  "notes": 
  "unit":
  "quantity": 
  "value": 
  "address": 
  "city":
  "state":
  "zip_code":
  "recipient_id":
  "status_id": 
  "provider_id": 
  "created_at": 
  "updated_at": 
}
```

_New response object when making POST request:_
```
{
  "id": 
  "service_type_id":
  "provided_at": 
  "notes": 
  "unit":
  "quantity": 
  "value": 
  "address": 
  "city":
  "state":
  "zip_code":
  "recipient_id":
  "status_id": 
  "provider_id": 
  "created_at": 
  "updated_at": 
  "first_name":
  "last_name": 
  "service_type_name":
  "status_name": 
}
```


- New routes have been tested locally with Postman