### PR TITLE
Created simple metric queries to work with hardcoded seed data

### DIFF
--- a/api/API-README.MD
+++ b/api/API-README.MD
@@ -332,18 +332,18 @@ To create or edit a recipient:
 
 All routes work with /api/metric or /api/metrics
 
-| Path               | Method | Requirements                                      | Authorization                            |
-| ------------------ | ------ | ------------------------------------------------- | ---------------------------------------- |
-| /api/metrics/recipientscount   | GET    | none                                  | none                                     |
-| /api/metrics/servicescount   | GET    | none                                  | none                                     |
-| /api/metrics/recipientsweek   | GET    | none                                  | none                                     |
-| /api/metrics/servicesweek  | GET    | none                                  | none                                     |
+| Path                         | Method | Requirements                                      | Authorization                            |
+| ---------------------------- | ------ | ------------------------------------------------- | ---------------------------------------- |
+| /api/metrics/recipientscount | GET    | none                                              | none                                     |
+| /api/metrics/servicescount   | GET    | none                                              | none                                     |
+| /api/metrics/recipientsweek  | GET    | none                                              | none                                     |
+| /api/metrics/servicesweek    | GET    | none                                              | none                                     |
 
 
 Metric object returned on GET requests:
 
 ```
-    {
-        count:int
-    }
+{
+    count:int
+}
 ```

--- a/api/API-README.MD
+++ b/api/API-README.MD
@@ -327,3 +327,23 @@ To create or edit a recipient:
     "household_characteristics":"Desired change as json object"
 }
 ```
+
+## Metrics
+
+All routes work with /api/metric or /api/metrics
+
+| Path               | Method | Requirements                                      | Authorization                            |
+| ------------------ | ------ | ------------------------------------------------- | ---------------------------------------- |
+| /api/metrics/recipientscount   | GET    | none                                  | none                                     |
+| /api/metrics/servicescount   | GET    | none                                  | none                                     |
+| /api/metrics/recipientsweek   | GET    | none                                  | none                                     |
+| /api/metrics/servicesweek  | GET    | none                                  | none                                     |
+
+
+Metric object returned on GET requests:
+
+```
+    {
+        count:int
+    }
+```

--- a/api/app.js
+++ b/api/app.js
@@ -28,6 +28,7 @@ const serviceEntryRouter = require('./serviceEntries/serviceEntriesRouter');
 const dsRouter = require('./dsService/dsRouter');
 const recipientRouter = require('./recipient/recipientRouter');
 const householdRouter = require('./household/householdRouter');
+const metricsRouter = require('./metrics/metricsRouter');
 
 const app = express();
 
@@ -64,6 +65,7 @@ app.use(['/api/service_entry', '/api/service_entries'], serviceEntryRouter);
 app.use('/data', dsRouter);
 app.use(['/api/recipient', '/api/recipients'], recipientRouter);
 app.use(['/api/household', '/api/households'], householdRouter);
+app.use(['/api/metric', '/api/metrics'], metricsRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/metrics/metricsModel.js
+++ b/api/metrics/metricsModel.js
@@ -1,20 +1,20 @@
 const knex = require('../../data/db-config');
 
-const findAllUniqueRecipients = async () => {
+const findAllUniqueRecipients = () => {
   return knex('recipients').count('id');
 };
 
-const findAllUniqueServices = async () => {
+const findAllUniqueServices = () => {
   return knex('service_entries').count('id');
 };
 
-const newRecipientsLastWeek = async () => {
+const newRecipientsLastWeek = () => {
   return knex('recipients')
     .count('id')
     .where('created_at', '>', '2021-05-17T00:00:00Z');
 };
 
-const newServicesLastWeek = async () => {
+const newServicesLastWeek = () => {
   return knex('service_entries')
     .count('id')
     .where('created_at', '>', '2021-05-17T00:00:00Z');

--- a/api/metrics/metricsModel.js
+++ b/api/metrics/metricsModel.js
@@ -1,0 +1,28 @@
+const knex = require('../../data/db-config');
+
+const findAllUniqueRecipients = async () => {
+  return knex('recipients').count('id');
+};
+
+const findAllUniqueServices = async () => {
+  return knex('service_entries').count('id');
+};
+
+const newRecipientsLastWeek = async () => {
+  return knex('recipients')
+    .count('id')
+    .where('created_at', '>', '2021-05-17T00:00:00Z');
+};
+
+const newServicesLastWeek = async () => {
+  return knex('service_entries')
+    .count('id')
+    .where('created_at', '>', '2021-05-17T00:00:00Z');
+};
+
+module.exports = {
+  findAllUniqueRecipients,
+  findAllUniqueServices,
+  newRecipientsLastWeek,
+  newServicesLastWeek,
+};

--- a/api/metrics/metricsRouter.js
+++ b/api/metrics/metricsRouter.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const Metric = require('./metricsModel');
+const router = express.Router();
+
+router.get('/recipientcount', (req, res) => {
+  Metric.findAllUniqueRecipients('recipients')
+    .then((recipients) => {
+      res.status(200).json(recipients);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+router.get('/servicescount', (req, res) => {
+  Metric.findAllUniqueRecipients('services')
+    .then((services) => {
+      res.status(200).json(services);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+router.get('/recipientsweek', (req, res) => {
+  Metric.newRecipientsLastWeek('new_recipients')
+    .then((new_recipients) => {
+      res.status(200).json(new_recipients);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+router.get('/servicesweek', (req, res) => {
+  Metric.findAllUniqueRecipients('new_service_entries')
+    .then((new_service_entries) => {
+      res.status(200).json(new_service_entries);
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+module.exports = router;

--- a/api/metrics/metricsRouter.js
+++ b/api/metrics/metricsRouter.js
@@ -2,8 +2,8 @@ const express = require('express');
 const Metric = require('./metricsModel');
 const router = express.Router();
 
-router.get('/recipientcount', (req, res) => {
-  Metric.findAllUniqueRecipients('recipients')
+router.get('/recipientscount', (req, res) => {
+  Metric.findAllUniqueRecipients()
     .then((recipients) => {
       res.status(200).json(recipients);
     })
@@ -13,7 +13,7 @@ router.get('/recipientcount', (req, res) => {
 });
 
 router.get('/servicescount', (req, res) => {
-  Metric.findAllUniqueRecipients('services')
+  Metric.findAllUniqueServices()
     .then((services) => {
       res.status(200).json(services);
     })
@@ -23,7 +23,7 @@ router.get('/servicescount', (req, res) => {
 });
 
 router.get('/recipientsweek', (req, res) => {
-  Metric.newRecipientsLastWeek('new_recipients')
+  Metric.newRecipientsLastWeek()
     .then((new_recipients) => {
       res.status(200).json(new_recipients);
     })
@@ -33,7 +33,7 @@ router.get('/recipientsweek', (req, res) => {
 });
 
 router.get('/servicesweek', (req, res) => {
-  Metric.findAllUniqueRecipients('new_service_entries')
+  Metric.newServicesLastWeek()
     .then((new_service_entries) => {
       res.status(200).json(new_service_entries);
     })


### PR DESCRIPTION
Invited Jennifer and Nathan to review.

- Created new Metrics API folder
- Connected new metrics router to app.js

Built four corresponding endpoints in MetricsRouter.js and metricsModel.js to achieve the following:
- Total unique Recipient count
- Total unique Service Entries count
- Total newly created Recipients in last 7 days count (hardcoded for 05/17/21 per seed data)
- Total newly created Service Entries in last 7 days count (hardcoded for 05/17/21 per seed data)

1 new folder created with 2 new files.
Modified existing app.js file.

This work was done to build out the bones of default metrics for the next cohort.

Tested the new endpoints and queries locally in Postman to ensure functionality.