### PR TITLE
Bug fix in migrations and seeds so provider_id to matches Okta

### DIFF
--- a/data/migrations/002-providers.js
+++ b/data/migrations/002-providers.js
@@ -1,6 +1,7 @@
 exports.up = (knex) => {
   return knex.schema.createTable('providers', (tbl) => {
-    tbl.uuid('provider_id').primary().defaultTo(knex.raw('gen_random_uuid ()'));
+    tbl.string('provider_id').primary();
+    // Does not autofill an id, we use the id that Okta generates
     tbl.string('role').notNullable();
     tbl.string('provider_first_name').notNullable();
     tbl.string('provider_last_name').notNullable();

--- a/data/migrations/005-program_providers.js
+++ b/data/migrations/005-program_providers.js
@@ -10,7 +10,7 @@ exports.up = function (knex) {
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
     tbl
-      .uuid('provider_id')
+      .string('provider_id')
       .unsigned()
       .notNullable()
       .references('provider_id')

--- a/data/migrations/007-service_type_providers.js
+++ b/data/migrations/007-service_type_providers.js
@@ -10,7 +10,7 @@ exports.up = function (knex) {
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
     tbl
-      .uuid('provider_id')
+      .string('provider_id')
       .unsigned()
       .notNullable()
       .references('provider_id')

--- a/data/migrations/017-service_entry_providers.js
+++ b/data/migrations/017-service_entry_providers.js
@@ -10,7 +10,7 @@ exports.up = (knex) => {
       .onUpdate('RESTRICT')
       .onDelete('RESTRICT');
     tbl
-      .uuid('provider_id')
+      .string('provider_id')
       .notNullable()
       .unsigned()
       .references('provider_id')

--- a/data/migrations/018-service_entry_recipients.js
+++ b/data/migrations/018-service_entry_recipients.js
@@ -10,11 +10,11 @@ exports.up = function (knex) {
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
     tbl
-      .uuid('provider_id')
+      .uuid('recipient_id')
       .notNullable()
       .unsigned()
-      .references('provider_id')
-      .inTable('providers')
+      .references('recipient_id')
+      .inTable('recipients')
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
     tbl.timestamps(true, true);

--- a/data/seeds/002_providers.js
+++ b/data/seeds/002_providers.js
@@ -1,6 +1,18 @@
 const providers = [
   {
-    provider_id: 'd49e0c39-010f-481c-862a-df8c193ed7ac',
+    provider_id: '00uk9lxaulDYOiB4H5d6',
+    role: 'Administrator',
+    provider_first_name: 'BG_User',
+    provider_last_name: 'Basic',
+    provider_email: 'bg_user@gmail.com',
+    provider_phone_number: '123-456-7894',
+    employee_id: 'A002',
+    provider_avatar_url: `https://avatars.dicebear.com/api/initials/${encodeURIComponent(
+      'bg_user basic'
+    )}.svg`,
+  },
+  {
+    provider_id: '00unr5lzndqVF13jP5d6',
     role: 'Administrator',
     provider_first_name: 'Abigail',
     provider_last_name: 'Administrator',
@@ -12,7 +24,7 @@ const providers = [
     )}.svg`,
   },
   {
-    provider_id: '3c5f8ea6-1df4-47c2-b468-99d377486ea3',
+    provider_id: '00unr48onuAmU9sxK5d6',
     role: 'Program Manager',
     provider_first_name: 'Patty',
     provider_last_name: 'Program',
@@ -24,7 +36,7 @@ const providers = [
     )}.svg`,
   },
   {
-    provider_id: '2d9f744c-b035-484f-9cc0-e9b718c9286c',
+    provider_id: '00unr8nm2sJkxkcrH5d6',
     role: 'Service Provider',
     provider_first_name: 'Sally',
     provider_last_name: 'Service',
@@ -33,6 +45,18 @@ const providers = [
     employee_id: 'SP001',
     provider_avatar_url: `https://avatars.dicebear.com/api/initials/${encodeURIComponent(
       'Sally Service'
+    )}.svg`,
+  },
+  {
+    provider_id: '00unr3s3m2zHx70ck5d6',
+    role: 'Unassigned',
+    provider_first_name: 'Gary',
+    provider_last_name: 'Jerry',
+    provider_email: 'fp.servicetracker+unassigned@gmail.com',
+    provider_phone_number: '123-456-7893',
+    employee_id: 'U001',
+    provider_avatar_url: `https://avatars.dicebear.com/api/initials/${encodeURIComponent(
+      'Gary Jerry'
     )}.svg`,
   },
 ];

--- a/data/seeds/005_program_providers.js
+++ b/data/seeds/005_program_providers.js
@@ -1,39 +1,39 @@
 const program_providers = [
   {
     program_id: 1,
-    provider_id: 'd49e0c39-010f-481c-862a-df8c193ed7ac',
+    provider_id: '00uk9lxaulDYOiB4H5d6',
   },
   {
     program_id: 2,
-    provider_id: 'd49e0c39-010f-481c-862a-df8c193ed7ac',
+    provider_id: '00unr3s3m2zHx70ck5d6',
   },
   {
     program_id: 3,
-    provider_id: 'd49e0c39-010f-481c-862a-df8c193ed7ac',
+    provider_id: '00unr5lzndqVF13jP5d6',
   },
   {
     program_id: 1,
-    provider_id: '3c5f8ea6-1df4-47c2-b468-99d377486ea3',
+    provider_id: '00unr48onuAmU9sxK5d6',
   },
   {
     program_id: 2,
-    provider_id: '3c5f8ea6-1df4-47c2-b468-99d377486ea3',
+    provider_id: '00unr48onuAmU9sxK5d6',
   },
   {
     program_id: 3,
-    provider_id: '3c5f8ea6-1df4-47c2-b468-99d377486ea3',
+    provider_id: '00unr48onuAmU9sxK5d6',
   },
   {
     program_id: 1,
-    provider_id: '2d9f744c-b035-484f-9cc0-e9b718c9286c',
+    provider_id: '00unr8nm2sJkxkcrH5d6',
   },
   {
     program_id: 2,
-    provider_id: '2d9f744c-b035-484f-9cc0-e9b718c9286c',
+    provider_id: '00unr8nm2sJkxkcrH5d6',
   },
   {
     program_id: 3,
-    provider_id: '2d9f744c-b035-484f-9cc0-e9b718c9286c',
+    provider_id: '00unr8nm2sJkxkcrH5d6',
   },
 ];
 

--- a/data/seeds/013-recipients.js
+++ b/data/seeds/013-recipients.js
@@ -6,7 +6,7 @@ const recipients = [
     recipient_last_name: 'ross',
     recipient_date_of_birth: '1970-10-12',
     recipient_veteran_status: false,
-    household_id: 'x', //need uuid
+    household_id: '457c9ef0-2386-40e1-9c32-c9b953f17da7',
     gender_id: 1,
     race_id: 1,
     ethnicity_id: 1,
@@ -18,7 +18,7 @@ const recipients = [
     recipient_last_name: 'ross1',
     recipient_date_of_birth: '1970-10-12',
     recipient_veteran_status: false,
-    household_id: 'x', //need uuid
+    household_id: 'ad8df54d-0c0d-4fb3-9ad8-bf50a64255ff',
     gender_id: 1,
     race_id: 1,
     ethnicity_id: 1,
@@ -30,7 +30,7 @@ const recipients = [
     recipient_last_name: 'ross2',
     recipient_date_of_birth: '1970-10-12',
     recipient_veteran_status: false,
-    household_id: 'x', //need uuid
+    household_id: 'd696b55e-fdf4-446f-a8a6-dcebaeaabef4',
     gender_id: 1,
     race_id: 1,
     ethnicity_id: 1,

--- a/data/seeds/013-recipients.js
+++ b/data/seeds/013-recipients.js
@@ -8,8 +8,8 @@ const recipients = [
     recipient_veteran_status: false,
     household_id: 'x', //need uuid
     gender_id: 1,
-    rade_id: 1,
-    ethnicity_id: 1
+    race_id: 1,
+    ethnicity_id: 1,
   },
   {
     recipient_id: '81a40c69-b004-4cc8-b6a5-424cbab89b8d',
@@ -20,8 +20,8 @@ const recipients = [
     recipient_veteran_status: false,
     household_id: 'x', //need uuid
     gender_id: 1,
-    rade_id: 1,
-    ethnicity_id: 1
+    race_id: 1,
+    ethnicity_id: 1,
   },
   {
     recipient_id: '1b1639f9-a614-4d15-93d8-1d0b27ca12a6',
@@ -32,8 +32,8 @@ const recipients = [
     recipient_veteran_status: false,
     household_id: 'x', //need uuid
     gender_id: 1,
-    rade_id: 1,
-    ethnicity_id: 1
+    race_id: 1,
+    ethnicity_id: 1,
   },
 ];
 

--- a/data/seeds/017-service_entry_providers.js
+++ b/data/seeds/017-service_entry_providers.js
@@ -1,7 +1,7 @@
 const service_entry_providers = [
   {
     service_entry_id: '5eefe344-263f-4248-8a8b-a005fde89fc7',
-    provider_id: 'x' // needs the provider id
+    provider_id: '00unr8nm2sJkxkcrH5d6',
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "rollback": "npm run knex migrate:rollback",
     "migrate": "npm run knex migrate:latest",
     "seed": "npm run knex seed:run",
+    "reset": "npm run rollback && npm run migrate && npm run seed",
     "migrateh": "npx heroku run npm run knex migrate:latest -a fp-service-tracker",
     "rollbackh": "npx heroku run npm run knex migrate:rollback -a fp-service-tracker",
-    "seedh": "npx heroku run npm run knex seed:run -a fp-service-tracker"
+    "seedh": "npx heroku run npm run knex seed:run -a fp-service-tracker",
+    "reseth": "npm run rollbackh && npm run migrateh && npm run seedh"
   },
   "lint-staged": {
     "api/**/*.js": [
@@ -116,4 +118,3 @@
     "supertest": "^4.0.2"
   }
 }
-


### PR DESCRIPTION
# Description

Bug fix to work with Okta

## What work was done?

- Updated migrations to change provider_id from uuid to string type.
  - Okta doesn't use UUIDs, it uses some other system.
 
- Updated seeds to match the Okta IDs
- Add the other valid Okta accounts

- Fixed typo in recipients seed
- Added household UUID from household table (from pending PR)

## Why was this work done?

- Needed to match the user account ids that Okta created so that DB works properly

## Type of change

- Bug Fix

## Change Status

- Completed, ready to review and merge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts