### PR TITLE
package-lock update to fix heroku deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "debug": "~2.6.9",
         "dotenv": "^8.2.0",
         "express": "~4.16.1",
-        "faker": "^4.1.0",
+        "faker": "^5.5.3",
         "helmet": "^3.23.1",
         "http-errors": "~1.6.3",
         "knex": "^0.21.1",
@@ -4035,9 +4035,9 @@
       ]
     },
     "node_modules/faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -15679,9 +15679,9 @@
       "dev": true
     },
     "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",


### PR DESCRIPTION
Why?
To fix heroku errors about mismatching package.json and package-lock.json