### PR TITLE
For findAll recips, add actual values, also zip

### DIFF
--- a/api/recipient/recipientModel.js
+++ b/api/recipient/recipientModel.js
@@ -1,5 +1,22 @@
 const knex = require('../../data/db-config');
 
+const findAll = () => {
+  return knex('recipients as r')
+    .leftJoin('households as h', 'r.household_id', 'h.household_id')
+    .leftJoin('genders as g', 'r.gender_id', 'g.gender_id')
+    .leftJoin('ethnicities as e', 'r.ethnicity_id', 'e.ethnicity_id')
+    .leftJoin('races as ra', 'r.race_id', 'ra.race_id')
+    .leftJoin('locations as l', 'h.location_id', 'l.location_id')
+    .select(
+      'r.*',
+      'ra.race',
+      'g.gender',
+      'e.ethnicity',
+      'h.household_name',
+      'l.zip'
+    );
+};
+
 const findByName = async (firstName, middleName, lastName) => {
   return await knex('recipients')
     .leftJoin('households', {
@@ -28,4 +45,5 @@ const findByName = async (firstName, middleName, lastName) => {
 
 module.exports = {
   findByName,
+  findAll,
 };

--- a/api/recipient/recipientRouter.js
+++ b/api/recipient/recipientRouter.js
@@ -10,7 +10,7 @@ const {
 // GET - View all recipients
 // All users can view all recipients
 router.get('/', (req, res) => {
-  DB.findAll('recipients')
+  Recipients.findAll('recipients')
     .then((recipients) => {
       res.status(200).json(recipients);
     })


### PR DESCRIPTION
# Description

Updating the get all recipients endpoint so it displays actual values and not just ids

## What work was done?

- Created new recipients findAll model
  - It returns not just the id of the value, but the actual value. Also, the zip code.
- Edited route to incorporate new model.
- Tested in Postman, the endpoint works correctly.

## Why was this work done?

It will help frontend in creating a nicer interface

## Type of change

- New feature (non-breaking change which adds functionality)

## Change Status

- Completed, ready to review and merge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
- [x] Endpoint tested with Postman, or other test.