### PR TITLE
Rework ServEntry delete, relevant migration update

### DIFF
--- a/api/serviceEntries/serviceEntriesModel.js
+++ b/api/serviceEntries/serviceEntriesModel.js
@@ -101,9 +101,14 @@ const update = (id, object) => {
     .returning('*');
 };
 
+const deleteRecord = (id) => {
+  return knex('service_entries').where('service_entry_id', id).del();
+};
+
 module.exports = {
   create,
   findAll,
   findById,
   update,
+  deleteRecord,
 };

--- a/api/serviceEntries/serviceEntriesRouter.js
+++ b/api/serviceEntries/serviceEntriesRouter.js
@@ -54,7 +54,7 @@ router.put('/:id', (req, res, next) => {
 
 router.delete('/:id', (req, res, next) => {
   const { id } = req.params;
-  DB.remove('service_entries', id)
+  ServiceEntries.deleteRecord(id)
     .then((count) => {
       if (count > 0) {
         res

--- a/data/migrations/007-service_type_providers.js
+++ b/data/migrations/007-service_type_providers.js
@@ -8,7 +8,7 @@ exports.up = function (knex) {
       .references('service_type_id')
       .inTable('service_types')
       .onUpdate('CASCADE')
-      .onDelete('RESTRICT');
+      .onDelete('CASCADE');
     tbl
       .string('provider_id')
       .unsigned()

--- a/data/migrations/008-service_type_categories.js
+++ b/data/migrations/008-service_type_categories.js
@@ -15,8 +15,8 @@ exports.up = function (knex) {
       .notNullable()
       .references('service_type_id')
       .inTable('service_types')
-      .onUpdate('RESTRICT')
-      .onDelete('RESTRICT');
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
     tbl.timestamps(true, true);
   });
 };

--- a/data/migrations/017-service_entry_providers.js
+++ b/data/migrations/017-service_entry_providers.js
@@ -7,16 +7,16 @@ exports.up = (knex) => {
       .unsigned()
       .references('service_entry_id')
       .inTable('service_entries')
-      .onUpdate('RESTRICT')
-      .onDelete('RESTRICT');
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
     tbl
       .string('provider_id')
       .notNullable()
       .unsigned()
       .references('provider_id')
       .inTable('providers')
-      .onUpdate('RESTRICT')
-      .onDelete('RESTRICT');
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
     tbl.timestamps(true, true);
   });
 };

--- a/data/migrations/018-service_entry_recipients.js
+++ b/data/migrations/018-service_entry_recipients.js
@@ -8,7 +8,7 @@ exports.up = function (knex) {
       .references('service_entry_id')
       .inTable('service_entries')
       .onUpdate('CASCADE')
-      .onDelete('RESTRICT');
+      .onDelete('CASCADE');
     tbl
       .uuid('recipient_id')
       .notNullable()
@@ -16,7 +16,7 @@ exports.up = function (knex) {
       .references('recipient_id')
       .inTable('recipients')
       .onUpdate('CASCADE')
-      .onDelete('RESTRICT');
+      .onDelete('CASCADE');
     tbl.timestamps(true, true);
   });
 };


### PR DESCRIPTION
# Description

Service Entry Delete Fix (Back End Only)

## What work was done?

With Kyle's guidance, a new delete function for Service Entries within the Service Entries modal was written that works. The previous one wasn't specific enough. The router now takes advantage of this, and relevant Migration tables have been edited, to allow for changes to cascade.

## Why was this work done?

 This was done to allow for tables utilizing the service entries table to update properly, and for Service Entries to be deletable.

## Type of change

Bug Fix, to allow for deletion. 

## Change Status

Ready for Review and Merge.

## Checklist

- [X] Endpoint tested with Postman, or Unit test.
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] There are no merge conflicts
