### PR TITLE
Added New Needed Columns to Households / Recipients Tables

### DIFF
--- a/data/migrations/009-households.js
+++ b/data/migrations/009-households.js
@@ -5,7 +5,7 @@ exports.up = function (knex) {
       .primary()
       .defaultTo(knex.raw('gen_random_uuid ()'));
     tbl.string('household_name', 255).notNullable();
-    tbl.boolean('is_unstable').notNullable().defaultTo(true);
+    tbl.boolean('is_unstable').notNullable().defaultTo(false);
     tbl.integer('household_size').notNullable();
     tbl.integer('household_income').notNullable();
     tbl

--- a/data/migrations/009-households.js
+++ b/data/migrations/009-households.js
@@ -5,6 +5,7 @@ exports.up = function (knex) {
       .primary()
       .defaultTo(knex.raw('gen_random_uuid ()'));
     tbl.string('household_name', 255).notNullable();
+    tbl.boolean('is_unstable').notNullable().defaultTo(true);
     tbl.integer('household_size').notNullable();
     tbl.integer('household_income').notNullable();
     tbl

--- a/data/migrations/013-recipients.js
+++ b/data/migrations/013-recipients.js
@@ -10,8 +10,8 @@ exports.up = (knex) => {
     tbl.date('recipient_date_of_birth').notNullable();
     tbl.boolean('recipient_veteran_status').notNullable();
     tbl.boolean('has_disability').notNullable().defaultTo(false);
-    tbl.boolean('has_valid_ssi').notNullable().defaultTo(true);
-    tbl.boolean('has_valid_medicare_card').notNullable().defaultTo(true);
+    tbl.boolean('has_valid_ssi').notNullable().defaultTo(false);
+    tbl.boolean('has_valid_medicare_card').notNullable().defaultTo(false);
       .uuid('household_id')
       // .notNullable() These are commented out since the create new recipient transaction is not complete
       .unsigned()

--- a/data/migrations/013-recipients.js
+++ b/data/migrations/013-recipients.js
@@ -12,6 +12,7 @@ exports.up = (knex) => {
     tbl.boolean('has_disability').notNullable().defaultTo(false);
     tbl.boolean('has_valid_ssi').notNullable().defaultTo(false);
     tbl.boolean('has_valid_medicare_card').notNullable().defaultTo(false);
+    tbl
       .uuid('household_id')
       // .notNullable() These are commented out since the create new recipient transaction is not complete
       .unsigned()

--- a/data/migrations/013-recipients.js
+++ b/data/migrations/013-recipients.js
@@ -9,7 +9,9 @@ exports.up = (knex) => {
     tbl.string('recipient_last_name').notNullable();
     tbl.date('recipient_date_of_birth').notNullable();
     tbl.boolean('recipient_veteran_status').notNullable();
-    tbl
+    tbl.boolean('has_disability').notNullable().defaultTo(false);
+    tbl.boolean('has_valid_ssi').notNullable().defaultTo(true);
+    tbl.boolean('has_valid_medicare_card').notNullable().defaultTo(true);
       .uuid('household_id')
       // .notNullable() These are commented out since the create new recipient transaction is not complete
       .unsigned()


### PR DESCRIPTION
# Description

Added "has_calid_ssi", "has_valid_medicare", "has_disability" columns to recipients table and "is_unstable" column to household table

## What work was done?

Details of your changes

Added "has_calid_ssi", "has_valid_medicare", "has_disability" columns to recipients table and "is_unstable" column to household table

## Why was this work done?

to help Data Science run an eligibility function that checks some of these values to determine eligibility for certain services, which is then communicated to service providers 

Why?

determining eligibility for services is required by law / necessary for resource allocation 

## Type of change

- New feature (non-breaking change which adds functionality)


## Change Status

- Completed, ready to review and merge?
- In progress?
- etc.

## Checklist

- [ ] Endpoint tested with Postman, or Unit test.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
