### PR TITLE
add qualify status to the recipient table

### DIFF
--- a/data/migrations/013-recipients.js
+++ b/data/migrations/013-recipients.js
@@ -9,9 +9,11 @@ exports.up = (knex) => {
     tbl.string('recipient_last_name').notNullable();
     tbl.date('recipient_date_of_birth').notNullable();
     tbl.boolean('recipient_veteran_status').notNullable();
+    tbl.boolean('qualify_status').notNullable();
     tbl.boolean('has_disability').notNullable().defaultTo(false);
     tbl.boolean('has_valid_ssi').notNullable().defaultTo(false);
     tbl.boolean('has_valid_medicare_card').notNullable().defaultTo(false);
+
     tbl
       .uuid('household_id')
       // .notNullable() These are commented out since the create new recipient transaction is not complete

--- a/data/seeds/013-recipients.js
+++ b/data/seeds/013-recipients.js
@@ -19,6 +19,7 @@ const recipients = fakeRecipientIds.map((id) => {
     gender_id: getRand(3),
     race_id: getRand(5),
     ethnicity_id: getRand(2),
+    qualify_status: faker.datatype.boolean(),
   };
 });
 


### PR DESCRIPTION
# Description

The front end demands for a change of the data structure for the recipient data obj, the recipient table will now take in qualify status as part of its attribute.

Summary of your changes

Added a new column in the recipient table, and change the seed file to generate mock data for it.

## What work was done?

Modify the recipient migration file by adding qualify_status column.
Modify the recipient seed file by adding one more random attribute for the qualify_status column.

## Why was this work done?

This work is done because the front end find it useful to manipulate data with this specific status variable there.

## Type of change

- New column for the recipient database


## Change Status

- Completed, ready to review and merge?
- In progress?
- etc.

## Checklist

- [ ] Endpoint tested with Postman, or Unit test.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
