### PR TITLE
Bug Fix - GET all service type programs

### DIFF
--- a/api/household/householdModel.js
+++ b/api/household/householdModel.js
@@ -1,7 +1,11 @@
 const knex = require('../../data/db-config');
 
 const findAll = async () => {
-  return knex("households as h").leftJoin("locations as l", "l.location_id", "h.location_id")
+  return knex('households as h').leftJoin(
+    'locations as l',
+    'l.location_id',
+    'h.location_id'
+  );
 };
 
 const findById = async (id) => {

--- a/api/serviceTypePrograms/serviceTypeProgramsModel.js
+++ b/api/serviceTypePrograms/serviceTypeProgramsModel.js
@@ -20,7 +20,8 @@ const findAll = async () => {
       'stp.service_type_program_id',
       'p.program_id',
       'st.service_type_id'
-    );
+    )
+    .orderBy([{ column: 'program_id' }, { column: 'service_type_name' }]);
 };
 
 const findById = async (id) => {

--- a/api/serviceTypePrograms/serviceTypeProgramsModel.js
+++ b/api/serviceTypePrograms/serviceTypeProgramsModel.js
@@ -9,9 +9,12 @@ const findAll = async () => {
       'stp.service_type_id'
     )
     .select(
-      knex.raw(
-        'service_type_programs.*, to_json(programs.*) as program, to_json(service_types.*) as service_type'
-      )
+      'service_type_program_id',
+      'stp.program_id',
+      'stp.service_type_id',
+      'program_name',
+      'service_type_name',
+      'service_type_entry_model'
     )
     .groupBy(
       'stp.service_type_program_id',


### PR DESCRIPTION
# Description

Summary of your changes

The GET request to the endpoint (api/serviceTypePrograms) was responding with an error. The response body has been corrected and will return all the information the frontend needs.

Loom Video link: https://www.loom.com/share/18041eacc60a47cfb1fc8309bc94c930

## What work was done?

I corrected the select statement in the findall() function for the  Service Type Programs model. I tested the response with Postman to ensure it is correct.

Details of your changes

## Why was this work done?

The frontend can now use this endpoint for the pull down menu on the Log Service form. service_type_program_id is a required field to post a service entry.

Why?

## Type of change

- Bug Fix

## Change Status

- Completed

## Checklist

- [X] Endpoint tested with Postman, or Unit test.
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] There are no merge conflicts
