### PR TITLE
Added 19 columns to api/maps GET response to populate map markers

### DIFF
--- a/api/maps/mapsModel.js
+++ b/api/maps/mapsModel.js
@@ -29,6 +29,11 @@ const findAllServiceEntryLocations = async () => {
       'r.recipient_last_name',
       'pd.provider_first_name',
       'pd.provider_last_name',
+      'l.address',
+      'l.address_line2',
+      'l.city',
+      'l.state',
+      'l.zip',
       'l.location_longitude',
       'l.location_latitude'
     );

--- a/api/maps/mapsModel.js
+++ b/api/maps/mapsModel.js
@@ -9,7 +9,29 @@ const findAllServiceEntryLocations = async () => {
     )
     .join('programs as p', 'stp.program_id', 'p.program_id')
     .join('locations as l', 'se.location_id', 'l.location_id')
-    .select('p.program_name', 'l.location_longitude', 'l.location_latitude');
+    .join('recipients as r', 'se.primary_recipient_id', 'r.recipient_id')
+    .join('providers as pd', 'se.primary_provider_id', 'pd.provider_id')
+    .join('service_types as st', 'stp.service_type_id', 'st.service_type_id')
+    .leftJoin('service_units as su', 'se.service_unit_id', 'su.service_unit_id')
+    .select(
+      'p.program_name',
+      'se.service_date',
+      'se.service_time',
+      'se.service_duration',
+      'se.service_value',
+      'se.service_quantity',
+      'su.service_unit_name',
+      'se.service_entry_notes',
+      'se.service_entry_data',
+      'st.service_type_name',
+      'st.service_type_description',
+      'r.recipient_first_name',
+      'r.recipient_last_name',
+      'pd.provider_first_name',
+      'pd.provider_last_name',
+      'l.location_longitude',
+      'l.location_latitude'
+    );
 };
 
 module.exports = {


### PR DESCRIPTION
# Description
Services (table service_entries) are represented as dots or "markers" on a map. Previously, the only data provided in addition to latitude and longitude was Program Name. After Stakeholder meeting on 10/7, client expressed interest in having additional data available on the map regarding service, provider and recipient.

Summary of your changes
Without specific requirements, added the following columns to the response from /api/maps GET:

  SERVICE_ENTRY:
     service_date,
     service_time,
     service_duration,
     service_value,
     service_quantity,
  SERVICE_UNITS:
     service_unit_name,
  SERVICE_ENTRY:
     service_entry_notes,
     service_entry_data,
  SERVICE_TYPE:
     service_type_name,
     service_type_description,
  RECIPIENTS:
     recipient_first_name,
     recipient_last_name,
  PROVIDERS:
     provider_first_name,
     provider_last_name
  LOCATION:
     address,
     address_line2,
     city,
     state,
     zip,

## What work was done?

This required adding full joins to tables RECIPIENTS, PROVIDERS and SERVICE_TYPES. It is assumed that the FK columns for all these tables are required in SERVICE_ENTRIES. If they are required, these columns should all have a NOT NULL constraint, otherwise a LEFT JOIN would be required to return all service entry records. A LEFT JOIN was required to include SERVICE_UNITS.SERVICE_UNIT_NAME. If this column is not required, that join could be removed, improving performance.

Details of your changes:

Changes to api/maps/mapsModel.js. See codes tab for details.

SQL implemented in knex:

```
SELECT
	p.program_name,
	se.service_date,
	se.service_time,
	se.service_duration,
	se.service_value,
	se.service_quantity,
	su.service_unit_name,
	se.service_entry_notes,
	se.service_entry_data,
	st.service_type_name,
	st.service_type_description,
	r.recipient_first_name,
	r.recipient_last_name,
	pd.provider_first_name,
	pd.provider_last_name,
	l.address,
	l.address_line2,
	l.city,
	l.state,
	l.zip,
	l.location_longitude,
	l.location_latitude
FROM
	service_entries se
JOIN service_type_programs stp
	ON se.service_type_program_id = stp.service_type_program_id
JOIN programs p
	ON stp.program_id = p.program_id
JOIN locations l
	ON se.location_id = l.location_id
JOIN recipients r
	ON se.primary_recipient_id = r.recipient_id
JOIN providers pd
	ON se.primary_provider_id = pd.provider_id
JOIN service_types st
	ON stp.service_type_id = st.service_type_id
LEFT JOIN service_units su
	ON se.service_unit_id = su.service_unit_id
```

## Why was this work done?
Requirements were transmitted verbally and approximately from Jake at the 10/7/21 Stakeholders Meeting. It is expected that these requirements will be refined, and it may be necessary to add or remove columns and table joins.

## Type of change

- New feature (non-breaking change which adds functionality)

## Change Status

- Completed, ready to review and merge

## Checklist

- [X ] Endpoint tested with Postman, or Unit test.
- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] My changes generate no new warnings
- [X ] There are no merge conflicts

## Testing
Tested modified endpoint in Swagger and Postman.
